### PR TITLE
Add tests for GameController and GameService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     }
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
+    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "com.auth0:java-jwt:4.3.0"

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GameService.java
@@ -35,7 +35,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class GameService {
     private final Logger log = LoggerFactory.getLogger(LobbyService.class);
 
-    private final IMemeApi memeApi = new ImgflipClient();
+    private final IMemeApi memeApi;
 
     private final LobbyService lobbyService;
 
@@ -46,9 +46,15 @@ public class GameService {
     @Autowired
     public GameService(@Qualifier("gameRepository") GameRepository gameRepository, JobScheduler jobScheduler,
             LobbyService lobbyService) {
+        this(gameRepository, jobScheduler, lobbyService, new ImgflipClient());
+    }
+
+    public GameService(GameRepository gameRepository, JobScheduler jobScheduler,
+                       LobbyService lobbyService, IMemeApi memeApi) {
         this.gameRepository = gameRepository;
         this.jobScheduler = jobScheduler;
         this.lobbyService = lobbyService;
+        this.memeApi = memeApi;
     }
 
     /**
@@ -108,7 +114,8 @@ public class GameService {
         List<Round> rounds = new ArrayList<Round>(lobby.getLobbySetting().getMaxRounds());
         Round round = new Round();
         round.setOpen(true);
-        round.setStartedAt(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        round.setStartedAt(now);
         round.setRoundNumber(1);
         rounds.add(0, round);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs23/service/GameService.java
@@ -114,8 +114,7 @@ public class GameService {
         List<Round> rounds = new ArrayList<Round>(lobby.getLobbySetting().getMaxRounds());
         Round round = new Round();
         round.setOpen(true);
-        LocalDateTime now = LocalDateTime.now();
-        round.setStartedAt(now);
+        round.setStartedAt(LocalDateTime.now());
         round.setRoundNumber(1);
         rounds.add(0, round);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/DtoMother.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/DtoMother.java
@@ -1,0 +1,24 @@
+package ch.uzh.ifi.hase.soprafs23;
+
+import ch.uzh.ifi.hase.soprafs23.rest.dto.meme.MemePostDTO;
+import ch.uzh.ifi.hase.soprafs23.rest.dto.rating.RatingPostDTO;
+
+import java.util.List;
+
+public class DtoMother {
+
+    public static RatingPostDTO buildRatingPostDTO() {
+        RatingPostDTO dto = new RatingPostDTO();
+        dto.setRating(1);
+        return dto;
+    }
+
+    public static MemePostDTO buildMemePostDTO() {
+        MemePostDTO dto = new MemePostDTO();
+        dto.setColor("color");
+        dto.setCurrentRound(1);
+        dto.setFontSize(2);
+        dto.setTextBoxes(List.of(EntityMother.defaulTextBox()));
+        return dto;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/EntityMother.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/EntityMother.java
@@ -1,0 +1,123 @@
+package ch.uzh.ifi.hase.soprafs23;
+
+import ch.uzh.ifi.hase.soprafs23.entity.*;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import java.util.*;
+
+public class EntityMother {
+
+    public static Lobby defaultLobby() {
+        LobbySetting lobbySetting = new LobbySetting();
+        lobbySetting.setMaxRounds(3);
+        lobbySetting.setRoundDuration(60);
+        lobbySetting.setRatingDuration(5);
+        lobbySetting.setMemeChangeLimit(2);
+
+        Lobby lobby = new Lobby();
+        lobby.setLobbySetting(lobbySetting);
+        lobby.setPlayers(List.of(defaultUser()));
+        return lobby;
+    }
+
+    public static Rating defaultRating() {
+        Rating r = new Rating();
+        r.setRating(1);
+        r.setMeme(defaultMeme(UUID.randomUUID()));
+        r.setUser(defaultUser());
+        return r;
+    }
+
+    public static Rating emptyRating() {
+        Rating r = new Rating();
+        r.setRating(1);
+        return r;
+    }
+
+    public static Meme defaultMeme(UUID memeId) {
+        Meme m = new Meme();
+        setPrivateFieldValue(m, "id", memeId);
+        m.setUser(defaultUser());
+        m.setTemplate(defaultTemplate("templateId"));
+        m.setColor("color");
+        m.setFontSize(2);
+        m.setTextBoxes(List.of(defaulTextBox()));
+        return m;
+    }
+
+    public static TextBox defaulTextBox() {
+        TextBox t = new TextBox();
+        t.setText("textbox");
+        return t;
+    }
+
+    public static Template defaultTemplate(String templateId) {
+        Template t = new Template();
+        setPrivateFieldValue(t, "id", templateId);
+        t.setImageUrl("imageURL");
+        return t;
+    }
+
+    public static Round openRound() {
+        Round r = new Round();
+        r.setOpen(true);
+        r.setMemes(new ArrayList<>());
+        r.setRatings(new ArrayList<>());
+        return r;
+    }
+
+    public static Round closedRound() {
+        Round r = openRound();
+        r.setOpen(false);
+        return r;
+    }
+
+    public static Game buildFullGame(Date date, String templateId) {
+        Game g = new Game();
+        g.setState(GameState.CREATION);
+        g.setCurrentRound(1);
+        g.setStartedAt(date);
+        g.setGameSetting(defaultGameSetting());
+        g.setPlayers(List.of(notReadyPlayer()));
+        g.setTemplates(List.of(defaultTemplate(templateId)));
+        g.setRounds(Arrays.asList(openRound()));
+        return g;
+    }
+
+    public static GameSetting defaultGameSetting() {
+        GameSetting gs = new GameSetting();
+        gs.setRatingDuration(1);
+        gs.setMaxRounds(1);
+        gs.setRatingDuration(10);
+        return gs;
+    }
+
+    public static Player notReadyPlayer() {
+        Player p = new Player();
+        p.setState(PlayerState.NOT_READY);
+        p.setUser(defaultUser());
+        return p;
+    }
+
+    public static Player notReadyPlayerWithUser(User user) {
+        Player p = new Player();
+        p.setState(PlayerState.NOT_READY);
+        p.setUser(user);
+        return p;
+    }
+
+    public static User defaultUser() {
+        User u = new User();
+        u.setName("Joe Bloggs");
+        u.setId("123");
+        return u;
+    }
+
+    private static void setPrivateFieldValue(Object o, String fieldName, Object value) {
+        try {
+            FieldUtils.writeField(o, fieldName, value, true);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GameControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/controller/GameControllerTest.java
@@ -1,83 +1,268 @@
-// package ch.uzh.ifi.hase.soprafs23.controller;
+package ch.uzh.ifi.hase.soprafs23.controller;
 
-// import ch.uzh.ifi.hase.soprafs23.entity.Game;
-// import ch.uzh.ifi.hase.soprafs23.entity.Lobby;
-// import ch.uzh.ifi.hase.soprafs23.entity.Meme;
-// import ch.uzh.ifi.hase.soprafs23.entity.Template;
-// import ch.uzh.ifi.hase.soprafs23.entity.User;
-// import ch.uzh.ifi.hase.soprafs23.rest.dto.meme.MemePostDTO;
-// import ch.uzh.ifi.hase.soprafs23.rest.mapper.meme.MemeMapper;
-// import ch.uzh.ifi.hase.soprafs23.service.GameService;
-// import ch.uzh.ifi.hase.soprafs23.service.LobbyService;
-// import ch.uzh.ifi.hase.soprafs23.service.UserService;
+import ch.uzh.ifi.hase.soprafs23.entity.Game;
+import ch.uzh.ifi.hase.soprafs23.entity.Meme;
+import ch.uzh.ifi.hase.soprafs23.entity.Player;
+import ch.uzh.ifi.hase.soprafs23.entity.Rating;
+import ch.uzh.ifi.hase.soprafs23.entity.Template;
+import ch.uzh.ifi.hase.soprafs23.entity.User;
+import ch.uzh.ifi.hase.soprafs23.security.JwtSecurityConfig;
+import ch.uzh.ifi.hase.soprafs23.service.GameService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.jobrunr.jobs.mappers.JobMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
 
-// import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
-// import org.junit.jupiter.api.Test;
-// import org.mockito.Mockito;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.boot.actuate.endpoint.SecurityContext;
-// import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-// import org.springframework.boot.test.mock.mockito.MockBean;
-// import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
-// import org.springframework.http.MediaType;
-// import org.springframework.security.core.context.SecurityContextHolder;
-// import org.springframework.security.core.userdetails.UserDetailsService;
-// import org.springframework.test.web.servlet.MockMvc;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static ch.uzh.ifi.hase.soprafs23.DtoMother.buildMemePostDTO;
+import static ch.uzh.ifi.hase.soprafs23.DtoMother.buildRatingPostDTO;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.buildFullGame;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultMeme;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultRating;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultTemplate;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultUser;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.emptyRating;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-// import java.util.UUID;
+@WebMvcTest(controllers = GameController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                JwtSecurityConfig.class
+        })
+public class GameControllerTest {
 
-// @WebMvcTest(GameController.class)
-// public class GameControllerTest {
+    private static final String FORMATTED_DATE = "2023-04-01T01:00:00.000+00:00";
+    private static final Date DATE = Date.from(Instant.parse(FORMATTED_DATE));
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectWriter OBJECT_WRITER = OBJECT_MAPPER.writer();
+    @Autowired
+    private MockMvc mockMvc;
 
-//     @Autowired
-//     private MockMvc mockMvc;
+    @MockBean
+    private GameService gameService;
 
-//     @MockBean
-//     private GameService gameService;
+    @MockBean
+    private JobMapper jobMapper;
 
-//     @MockBean
-//     private LobbyService lobbyService;
+    @Test
+    public void givenLobbyCode_whenCreateGame_thenReturnCreatedGame() throws Exception {
+        String lobbyCode = "testCode";
+        Game game = buildFullGame(DATE, "templateId");
 
-//     @MockBean
-//     private UserService userService;
+        when(gameService.createGame(lobbyCode)).thenReturn(game);
 
-//     @MockBean
-//     private UserDetailsService userDetailsService;
+        Player firstPlayer = game.getPlayers().get(0);
+        mockMvc.perform(post("/games/{lobbyCode}", lobbyCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("id", is(game.getId())))
+                .andExpect(jsonPath("gameState", is(game.getState().toString())))
+                .andExpect(jsonPath("roundDuration", is(game.getGameSetting().getRoundDuration())))
+                .andExpect(jsonPath("votingDuration", is(game.getGameSetting().getRatingDuration())))
+                .andExpect(jsonPath("currentRound", is(game.getCurrentRound())))
+                .andExpect(jsonPath("totalRounds", is(game.getGameSetting().getMaxRounds())))
+                .andExpect(jsonPath("startedAt", is(FORMATTED_DATE)))
+                .andExpect(jsonPath("players", hasSize(1)))
+                .andExpect(jsonPath("players[0].name", is(nullValue()))) //TODO: is this correct?
+                .andExpect(jsonPath("players[0].id", is(nullValue()))) //TODO: is this correct?
+                .andExpect(jsonPath("players[0].user.name", is(firstPlayer.getUser().getName())))
+                .andExpect(jsonPath("players[0].user.id", is(firstPlayer.getUser().getId())));
+    }
 
-//     @Test
-//     public void givenLobbyCode_whenCreateGame_thenReturnCreatedGame() throws Exception {
-//         String lobbyCode = "testCode";
-//         Lobby lobby = new Lobby();
-//         Game game = new Game();
+    @Test
+    public void givenGameId_whenGetGame_thenReturnGame() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        Game game = buildFullGame(DATE, "templateId");
 
-//         when(lobbyService.getLobbyByCode(lobbyCode)).thenReturn(lobby);
-//         when(gameService.createGame(lobbyCode)).thenReturn(game);
+        when(gameService.getGame(gameId)).thenReturn(game);
 
-//         mockMvc.perform(post("/games/{lobbyCode}", lobbyCode)
-//                 .contentType(MediaType.APPLICATION_JSON))
-//                 .andExpect(status().isCreated());
-//     }
+        mockMvc.perform(get("/games/{gameId}", gameId))
+                .andExpect(status().isOk())
+                .andExpectAll(verifyGameResponseBody(game));
+    }
 
-//     @Test
-//     public void givenGameId_whenGetGame_thenReturnGame() throws Exception {
-//         String gameId = UUID.randomUUID().toString();
-//         Game game = new Game();
+    @Test
+    public void givenTemplateId_whenGetTemplate_thenReturnTemplate() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        User user = defaultUser();
+        Template template = defaultTemplate("templateId");
 
-//         when(gameService.getGame(gameId)).thenReturn(game);
+        givenUserIsAuthenticated(user);
 
-//         mockMvc.perform(get("/games/{gameId}", gameId)
-//                 .contentType(MediaType.APPLICATION_JSON))
-//                 .andExpect(status().isOk());
-//     }
+        when(gameService.getTemplate(gameId, user)).thenReturn(template);
 
-//     // Add more tests for the other GameController methods
-// }
+        mockMvc.perform(get("/games/{gameId}/template", gameId))
+                .andExpect(status().isOk())
+                .andExpectAll(jsonPath("id", is(template.getId())),
+                        jsonPath("imageUrl", is(template.getImageUrl())));
+    }
+
+    @Test
+    public void givenGameIdTemplateIdAndMeme_whenCreateMeme_thenReturnCreatedStatus() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        String templateId = UUID.randomUUID().toString();
+        User user = defaultUser();
+        Meme meme = defaultMeme(UUID.randomUUID());
+        meme.setTemplate(null);
+        meme.setUser(null);
+
+        givenUserIsAuthenticated(user);
+
+        mockMvc.perform(post("/games/{gameId}/meme/{templateId}", gameId, templateId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_WRITER.writeValueAsString(buildMemePostDTO())))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<Meme> memeArgumentCaptor = ArgumentCaptor.forClass(Meme.class);
+        verify(gameService).createMeme(eq(gameId), eq(templateId), memeArgumentCaptor.capture(), eq(user));
+        assertThat(memeArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .ignoringFields("id")
+                .isEqualTo(meme);
+    }
+
+    @Test
+    public void givenGameId_whenGetMemes_thenReturnMemes() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        Meme meme = defaultMeme(UUID.randomUUID());
+
+        when(gameService.getMemes(gameId)).thenReturn(List.of(meme));
+
+        mockMvc.perform(get("/games/{gameId}/meme", gameId))
+                .andExpect(status().isCreated()) //TODO: is this correct? Should it not be "OK"
+                .andExpectAll(jsonPath("$", hasSize(1)),
+                        jsonPath("$[0].id", is(meme.getId().toString())),
+                        jsonPath("$[0].imageUrl", is(meme.getTemplate().getImageUrl())),
+                        jsonPath("$[0].textBoxes", hasSize(1)),
+                        jsonPath("$[0].textBoxes[0].text", is(meme.getTextBoxes().get(0).getText())));
+                        jsonPath("$[0].textBoxes[0].x", is(nullValue()));
+                        jsonPath("$[0].textBoxes[0].y", is(nullValue()));
+    }
+
+    @Test
+    public void givenGameIdMemeIdAndRating_whenCreateRating_thenReturnOkStatus() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        UUID memeId = UUID.randomUUID();
+        User user = defaultUser();
+        Rating rating = emptyRating();
+
+        givenUserIsAuthenticated(user);
+
+        mockMvc.perform(post("/games/{gameId}/rating/{memeId}", gameId, memeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_WRITER.writeValueAsString(buildRatingPostDTO())))
+                .andExpect(status().isOk()); // TODO: is this correct? Should it not be "Created"
+
+
+        ArgumentCaptor<Rating> argumentCaptor = ArgumentCaptor.forClass(Rating.class);
+        verify(gameService).createRating(eq(gameId), eq(memeId), argumentCaptor.capture(), eq(user));
+        assertThat(argumentCaptor.getValue()).usingRecursiveComparison()
+                .isEqualTo(rating);
+    }
+
+    @Test
+    public void givenGameId_whenSetPlayerReady_thenReturnOkStatus() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        User user = defaultUser();
+
+        givenUserIsAuthenticated(user);
+
+        mockMvc.perform(post("/games/{gameId}/ready", gameId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(gameService).setPlayerReady(gameId, user);
+    }
+
+    @Test
+    public void givenGameId_whenGetRatingsFromRound_thenRatings() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        Rating rating = defaultRating();
+
+        when(gameService.getRatingsFromRound(gameId)).thenReturn(List.of(rating));
+
+        mockMvc.perform(get("/games/{gameId}/rating", gameId))
+                .andExpect(status().isOk())
+                .andExpectAll(verifyRatingResponseBody(rating));
+    }
+
+    @Test
+    public void givenGameId_whenGetAllRatings_thenRatings() throws Exception {
+        String gameId = UUID.randomUUID().toString();
+        Rating rating = defaultRating();
+
+        when(gameService.getAllRatings(gameId)).thenReturn(List.of(rating));
+
+        mockMvc.perform(get("/games/{gameId}/winner", gameId))
+                .andExpect(status().isOk())
+                .andExpectAll(verifyRatingResponseBody(rating));
+    }
+
+    private static void givenUserIsAuthenticated(User user) {
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(user);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    private static ResultMatcher[] verifyRatingResponseBody(Rating rating) {
+        return new ResultMatcher[]{jsonPath("$", hasSize(1)),
+                jsonPath("$[0].rating", is(rating.getRating())),
+                jsonPath("$[0].user.id", is(rating.getUser().getId())),
+                jsonPath("$[0].user.name", is(rating.getUser().getName())),
+                jsonPath("$[0].meme.id", is(rating.getMeme().getId().toString())),
+                jsonPath("$[0].meme.template.id", is(rating.getMeme().getTemplate().getId())),
+                jsonPath("$[0].meme.template.imageUrl", is(rating.getMeme().getTemplate().getImageUrl())),
+                jsonPath("$[0].meme.color", is(rating.getMeme().getColor())),
+                jsonPath("$[0].meme.fontSize", is(rating.getMeme().getFontSize())),
+                jsonPath("$[0].meme.textBoxes[0].text", is(rating.getMeme().getTextBoxes().get(0).getText())),
+                jsonPath("$[0].meme.textBoxes[0].x", is(rating.getMeme().getTextBoxes().get(0).getX())),
+                jsonPath("$[0].meme.textBoxes[0].y", is(rating.getMeme().getTextBoxes().get(0).getY())),
+                jsonPath("$[0].meme.user.id", is(rating.getMeme().getUser().getId())),
+                jsonPath("$[0].meme.user.name", is(rating.getMeme().getUser().getName()))};
+    }
+
+    private static ResultMatcher[] verifyGameResponseBody(Game game) {
+        return new ResultMatcher[]{
+                jsonPath("id", is(game.getId())),
+                jsonPath("gameState", is(game.getState().toString())),
+                jsonPath("roundDuration", is(game.getGameSetting().getRoundDuration())),
+                jsonPath("votingDuration", is(game.getGameSetting().getRatingDuration())),
+                jsonPath("currentRound", is(game.getCurrentRound())),
+                jsonPath("totalRounds", is(game.getGameSetting().getMaxRounds())),
+                jsonPath("startedAt", is(FORMATTED_DATE)),
+                jsonPath("players", hasSize(1)),
+                jsonPath("players[0].name", is(nullValue())),
+                jsonPath("players[0].id", is(nullValue())),
+                jsonPath("players[0].user.name", is(game.getPlayers().get(0).getUser().getName())),
+                jsonPath("players[0].user.id", is(game.getPlayers().get(0).getUser().getId()))};
+    }
+}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs23/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs23/service/GameServiceTest.java
@@ -1,121 +1,371 @@
 package ch.uzh.ifi.hase.soprafs23.service;
 
-import java.lang.reflect.Field;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-
+import ch.uzh.ifi.hase.soprafs23.entity.Game;
+import ch.uzh.ifi.hase.soprafs23.entity.GameState;
+import ch.uzh.ifi.hase.soprafs23.entity.Meme;
+import ch.uzh.ifi.hase.soprafs23.entity.Player;
+import ch.uzh.ifi.hase.soprafs23.entity.PlayerState;
+import ch.uzh.ifi.hase.soprafs23.entity.Rating;
+import ch.uzh.ifi.hase.soprafs23.entity.Round;
+import ch.uzh.ifi.hase.soprafs23.entity.Template;
+import ch.uzh.ifi.hase.soprafs23.entity.User;
+import ch.uzh.ifi.hase.soprafs23.repository.GameRepository;
+import ch.uzh.ifi.hase.soprafs23.utility.memeapi.IMemeApi;
+import ch.uzh.ifi.hase.soprafs23.utility.memeapi.ImgflipClient;
+import org.assertj.core.groups.Tuple;
 import org.jobrunr.scheduling.JobScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs23.entity.Game;
-import ch.uzh.ifi.hase.soprafs23.entity.Lobby;
-import ch.uzh.ifi.hase.soprafs23.entity.LobbySetting;
-import ch.uzh.ifi.hase.soprafs23.entity.Rating;
-import ch.uzh.ifi.hase.soprafs23.entity.Round;
-import ch.uzh.ifi.hase.soprafs23.repository.GameRepository;
-import ch.uzh.ifi.hase.soprafs23.repository.LobbyRepository;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.buildFullGame;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.closedRound;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultLobby;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultMeme;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultRating;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.defaultUser;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.notReadyPlayerWithUser;
+import static ch.uzh.ifi.hase.soprafs23.EntityMother.openRound;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 public class GameServiceTest {
     @Mock
     private GameRepository gameRepository;
-
     @Mock
     private LobbyService lobbyService;
-
     @Mock
-    private LobbyRepository lobbyRepository;
-
+    private IMemeApi iMemeApi;
     @Mock
     private JobScheduler jobScheduler;
-
-    @InjectMocks
     private GameService gameService;
-
-    private Game testGame;
-
-    private Lobby testLobby;
-
-    private LobbySetting lobbySetting;
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.openMocks(this);
-
-        // given
-        testGame = new Game();
-
-        testLobby = new Lobby();
-        testLobby.setCode("123");
-
-        // Set up LobbySetting for the testLobby
-        lobbySetting = new LobbySetting();
-        lobbySetting.setMaxRounds(5);
-        lobbySetting.setRoundDuration(60);
-        lobbySetting.setRatingDuration(30);
-        lobbySetting.setMemeChangeLimit(3);
-        testLobby.setLobbySetting(lobbySetting);
-        testLobby.setPlayers(new ArrayList<>());
-
-        // Set the id of testGame using reflection
-        try {
-            Field idField = Game.class.getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(testGame, UUID.randomUUID().toString());
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-        }
-
-        // when -> any object is being save in the lobbyRepository -> return the dummy testGame
-        Mockito.when(gameRepository.save(any())).thenReturn(testGame);
-
+        gameService = new GameService(gameRepository, jobScheduler, lobbyService, iMemeApi);
     }
-    
 
     @Test
-    public void createGame_validInputs_success() {
-        // given
-        String testLobbyCode = "testLobbyCode";
-        
+    void createGame_validInputs_success() {
+        ImgflipClient.ApiResponse apiResponse = buildIMemeAPIResponse();
+        when(iMemeApi.getTemplates()).thenReturn(apiResponse);
 
-        Mockito.when(lobbyService.getLobbyByCode(testLobbyCode)).thenReturn(testLobby);
+        String lobbyCode = "lobbyCode";
+        when(lobbyService.getLobbyByCode(lobbyCode)).thenReturn(defaultLobby());
 
-        // when
-        Game createdGame = gameService.createGame(testLobbyCode);
+        Game game = gameService.createGame(lobbyCode);
 
-        // then
-        assertEquals(lobbySetting.getMaxRounds(), createdGame.getGameSetting().getMaxRounds());
-        assertEquals(lobbySetting.getRoundDuration(), createdGame.getGameSetting().getRoundDuration());
-        assertEquals(lobbySetting.getRatingDuration(), createdGame.getGameSetting().getRatingDuration());
-        assertEquals(lobbySetting.getMemeChangeLimit(), createdGame.getGameSetting().getTemplateSwapLimit());
-        verify(gameRepository, times(1)).save(any());
-        verify(lobbyService, times(1)).getLobbyByCode(testLobbyCode);
+        verify(gameRepository).save(game);
+        verify(gameRepository).flush();
+        verify(lobbyService).setGameStarted(lobbyCode, game.getId(), game.getStartedAt());
+
+
+        assertThat(game.getState()).isEqualTo(GameState.CREATION);
+        assertThat(game.getCurrentRound()).isEqualTo(1);
+        assertThat(game.getTemplates())
+                .extracting("imageUrl")
+                        .contains(apiResponse.data.memes.get(0).url);
+        assertThat(game.getPlayers())
+                .extracting("state")
+                .containsExactly(PlayerState.READY);
+        assertThat(game.getRounds()).hasSize(1);
+        assertThat(game.getRounds())
+                .extracting("isOpen", "roundNumber")
+                .contains(Tuple.tuple(true, 1));
     }
-
 
     @Test
     public void getGame_validGameId_success() {
-        when(gameRepository.findById(testGame.getId())).thenReturn(java.util.Optional.ofNullable(testGame));
+        String gameId = "gameId";
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
 
-        // when
-        Game fetchedGame = gameService.getGame(testGame.getId());
+        Game actual = gameService.getGame(gameId);
 
-        // then
-        assertEquals(testGame, fetchedGame);
-        verify(gameRepository, times(1)).findById(testGame.getId());
+        assertThat(actual).isEqualTo(game);
     }
 
+    @Test
+    public void getGame_unknownGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.getGame(gameId));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void getTemplate_validGameId_success() {
+        String gameId = "gameId";
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        Template actual = gameService.getTemplate(gameId, defaultUser());
+
+        assertThat(actual).isEqualTo(game.getTemplate());
+    }
+
+    @Test
+    public void getTemplate_unknownGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.getTemplate(gameId, defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void createMeme_validGameId_success() {
+        String gameId = "gameId";
+        String templateId = "templateId";
+
+        Game game = buildFullGame(new Date(), "templateId");
+        Meme meme = defaultMeme(UUID.randomUUID());
+
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.createMeme(gameId, templateId, meme, defaultUser());
+
+        verify(gameRepository).save(any(Game.class));
+        verify(gameRepository).flush();
+    }
+
+    @Test
+    public void createMeme_unknownGameId_failure() {
+        String gameId = "gameId";
+        String templateId = "templateId";
+
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.createMeme(gameId, templateId, defaultMeme(UUID.randomUUID()), defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void createMeme_closedRound_failure() {
+        String gameId = "gameId";
+        String templateId = "templateId";
+
+        Game game = buildFullGame(new Date(), "templateId");
+        game.setRound(closedRound());
+        Meme meme = defaultMeme(UUID.randomUUID());
+
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        Throwable t = catchThrowable(() -> gameService.createMeme(gameId, templateId, meme, defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Round is not open"));
+    }
+
+    @Test
+    public void getMemes_validGameId_success() {
+        String gameId = "gameId";
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        List<Meme> memes = gameService.getMemes(gameId);
+
+        assertThat(memes).isEqualTo(game.getRound().getMemes());
+    }
+
+    @Test
+    public void getMemes_unknownGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.getMemes(gameId));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void createRating_unknownGameId_failure() {
+        String gameId = "gameId";
+        UUID memeId = UUID.randomUUID();
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.createRating(gameId, memeId, defaultRating(), defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void createRating_unknownMemeId_failure() {
+        String gameId = "gameId";
+        UUID unknownMemeId = UUID.randomUUID();
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        Throwable t = catchThrowable(() -> gameService.createRating(gameId, unknownMemeId, defaultRating(), defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Meme not found"));
+    }
+
+    @Test
+    public void createRating_validMemeId_success() {
+        String gameId = "gameId";
+        UUID memeId = UUID.randomUUID();
+        Game game = buildFullGame(new Date(), "templateId");
+        Round round = openRound();
+        round.setMemes(List.of(defaultMeme(memeId)));
+        game.setRounds(Arrays.asList(round));
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.createRating(gameId, memeId, defaultRating(), defaultUser());
+
+        verify(gameRepository).save(any(Game.class));
+        verify(gameRepository).flush();
+    }
+
+    @Test
+    public void setPlayerReady_validGameId_success() {
+        String gameId = "gameId";
+        User user = defaultUser();
+        Game game = buildFullGame(new Date(), "templateId");
+        List<Player> players = List.of(notReadyPlayerWithUser(user));
+        game.setPlayers(players);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.setPlayerReady(gameId, user);
+
+
+        ArgumentCaptor<Game> gameArgumentCaptor = ArgumentCaptor.forClass(Game.class);
+        verify(gameRepository).save(gameArgumentCaptor.capture());
+        verify(gameRepository).flush();
+
+        Game actual = gameArgumentCaptor.getValue();
+        assertThat(actual.getPlayers())
+                .extracting("state")
+                .contains(PlayerState.READY);
+    }
+
+    @Test
+    public void setPlayerReady_noMatchingUserId_failure() {
+        String gameId = "gameId";
+        User user = defaultUser();
+        user.setId("unknownId");
+        Game game = buildFullGame(new Date(), "templateId");
+        List<Player> players = List.of(notReadyPlayerWithUser(user));
+        game.setPlayers(players);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.setPlayerReady(gameId, defaultUser());
+
+        ArgumentCaptor<Game> gameArgumentCaptor = ArgumentCaptor.forClass(Game.class);
+        verify(gameRepository).save(gameArgumentCaptor.capture());
+        verify(gameRepository).flush();
+
+        Game actual = gameArgumentCaptor.getValue();
+        assertThat(actual.getPlayers())
+                .extracting("state")
+                .contains(PlayerState.NOT_READY);
+    }
+
+    @Test
+    public void setPlayerReady_invalidGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.setPlayerReady(gameId, defaultUser()));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void getRatingsFromRound_unknownGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.getRatingsFromRound(gameId));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void getRatingsFromRound_validGameId_success() {
+        String gameId = "gameId";
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        List<Rating> ratingsFromRound = gameService.getRatingsFromRound(gameId);
+
+        assertThat(ratingsFromRound).isEqualTo(game.getRound().getRatings());
+    }
+
+    @Test
+    public void getAllRatings_unknownGameId_failure() {
+        String gameId = "gameId";
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        Throwable t = catchThrowable(() -> gameService.getAllRatings(gameId));
+
+        assertThat(t).usingRecursiveComparison()
+                .isInstanceOf(ResponseStatusException.class)
+                .isEqualTo(new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found"));
+    }
+
+    @Test
+    public void getAllRatings_validGameId_success() {
+        String gameId = "gameId";
+        Game game = buildFullGame(new Date(), "templateId");
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        List<Rating> allRatings = gameService.getRatingsFromRound(gameId);
+
+        List<Rating> collect = game.getRounds()
+                .stream()
+                .map(Round::getRatings)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertThat(allRatings).isEqualTo(collect);
+    }
+
+    private static ImgflipClient.ApiResponse buildIMemeAPIResponse() {
+        ImgflipClient.ApiResponse apiResponse = new ImgflipClient.ApiResponse();
+        ImgflipClient.Data data = new ImgflipClient.Data();
+        ImgflipClient.Meme meme = new ImgflipClient.Meme();
+        meme.url = "url";
+        data.memes = List.of(meme);
+        apiResponse.data = data;
+        return apiResponse;
+    }
 }


### PR DESCRIPTION
In order to add tests, i have adopted the [ObjectMother Pattern](https://martinfowler.com/bliki/ObjectMother.html) which removes some of the boilerplate for creating the entities. The entities should NOT be mocked as they are fundamental to the application. The ObjectMother works quite nicely where you can encapsulate business logic inside the Factory function with what is being created (for example see the OpenRound and ClosedRound functions). 
Using these functions, I have been able to add all supporting tests to the GameController (which are Spring MockMVC tests) and into the GameService (which are standard unit tests). 

In order for me to test more effectively, I have made the iMemeAPI injectable meaning I can pass in a Mock into the constructor, i, however, have left the `@Autowired` constructor as-is and passed the ` new ImgflipClient()` in (see code for these changes), thus, behaving as you had it (when you run the application), this use of Dependency Injection allows the tests to become less coupled to the "real" implementation and therefore are less flakey (i.e if the API was ever down, these tests would break with the real implementation). 
I have also added the common-langs library to the project as this allows me to more easily set the id of the entities through Reflection (which you had before, but this allows for a "one liner"), i have wrapped this up into a small "setPrivateFieldValue" function as you will see.

I don't think you need any more in-depth integration tests (that test via the controller into the Service) as most of your business logic is inside the Service so as long as you have a good level of testing here, this should be enough.

There are a number of improvements that i feel could be made to the code in the main folder, specifically in the GameService but we can talk about that another time if you wish.